### PR TITLE
Add travis.yaml build and deploy artifacts to github

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,17 +1,17 @@
 project_name: kubeadm-bootstrap
 builds:
-- goos:
-  - linux
-  - darwin
-  goarch:
-  - amd64
-  main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-  binary: kubeadm-bootstrap
+  -
+    goos:
+    - linux
+    - darwin
+    goarch:
+    - amd64
+    main: .
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    binary: kubeadm-bootstrap
 archive:
   format: tar.gz
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
-    }}v{{ .Arm }}{{ end }}'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   files:
   - licence*
   - LICENCE*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: go
+
+go:
+  - '1.10'
+branches:
+  only:
+  - master
+
+deploy:
+  -
+    provider: releases
+    api_key:
+      secure: PiFH86WQxKiAuWnZgmfaWIde9YdrTTYQ1xeCQ87GAtgkqgA4UJAqD78qh1cFX7l4l9QIl6aG0g5IljVC+IKGsk4SJbuJbr25R1qn8AK0DwGbt44FaDNsF+ZKUWfXf30GzfleSUlOzUuPyW6b2WDub8M3Vo9zIrkt/wnSWUjpWopEju+BG9tHUbhiZB3k00Hlm9AFXei2ZcfygQQpHt6xGDaMW3JryUJpE0Jz3PrwNXVSyKLleFZDYETIXL7tcb5HHFybTGf9nwrAQjGb/ZLha3K0FI7zOF1S3hcFTqkAvjxEU4cNVg25ya069NbfYpTpqaKC1GlxSWwlUNvBlGb2c2hAv63/iMr/AjcEDq+Lvui0SJZlg98X0fTfcYXvSwH1KmCyNCOIDmf4dtzRwcRP4jqzQ6txsREn1imC1MjgGCML4ugj2ZIzwAPKOUqTBqvFXfoL0ZPkdADTCH9CM2EDQ3HPBRuR5N4FGlfUoqOzRmIKT79oEg7OK1ElPhSeSukZpOEVMIrV0aQ/UKGBfY19nxU+RbzMtrOsT/IKtL40IZOxRZ2e2+nQa6nb92aCQcP5k4IQp1QFCt64UdMBsz5nD79nRRUmWu8W8nlJKSfl58mHHJbJRaqnnJzS+q5elaRWvDM89otXwb9dOUyETI9NtP1tilE4y5V3SxB+PcPui+c=
+    file:
+      - "dist/kubeadm-bootstrap_*_checksums.txt"
+      - "dist/kubeadm-bootstrap_*_darwin_amd64.tar.gz"
+      - "dist/kubeadm-bootstrap_*_linux_amd64.tar.gz"
+      - "dist/kubeadm-bootstrap_*_linux_amd64.rpm"
+      - dist/darwin_amd64/kubeadm-bootstrap
+      - dist/linux_amd64/kubeadm-bootstrap
+    on:
+      repo: apptio/kubeadm-bootstrap
+      tags: true
+
+script:
+  - curl -sO http://git.io/goreleaser
+
+notifications:
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
-clean:
-	@rm -rf ./dist
+# VERSION is the last git tag
+# e.g. 0.1
+VERSION = $(shell git describe --abbrev=0)
+
+# GOVERSION is the current go version
+# e.g. go1.10
+GOVERSION = $(shell go version | awk '{print $$3;}')
+
+# GORELEASER is the path to the goreleaser binary.
+# e.g. /usr/local/bin/goreleaser
+GORELEASER = $(shell which goreleaser)
+
+.PHONY: clean build
 
 build: clean
-	@goreleaser --skip-publish
+	@[ -x "$(GORELEASER)" ] || ( echo "goreleaser not installed"; exit 1)
+	@GOVERSION=$(GOVERSION) goreleaser --rm-dist
+
+clean:
+	@rm -rf dist pkg kubeadm-bootstrap

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # kubeadm-bootstrap
 
+[![Build Status](https://travis-ci.org/apptio/kubeadm-bootstrap.svg?branch=master)](https://travis-ci.org/apptio/kubeadm-bootstrap)
+
 kubeadm-bootstrap is a simple tool to generate [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/) configuration files.
 
 It uses [jsonnet](http://jsonnet.org/) to template the resulting JSON formatted kubeadm configuration file, meaning you can easily generate configurations for kubeadm, which can then be passed to a configuration management tool like [Puppet](https://puppet.com/) or [Chef](https://www.chef.io/chef/)


### PR DESCRIPTION
* Updates goreleaser config
* Adds travis.yaml
* Moves make build target to the top so it is the default target
* Adds travis badge to README

https://travis-ci.org/apptio/kubeadm-bootstrap
