### PR TITLE
Add logging options, write logging info to stderr, and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM goreleaser/goreleaser
+
+RUN go get -d github.com/apptio/kubeadm-bootstrap && \
+    cd ${GOPATH}/src/github.com/apptio/kubeadm-bootstrap && \
+    CGO_ENABLED=0 go install
+RUN /go/bin/kubeadm-bootstrap --help
+
+FROM scratch
+WORKDIR /
+COPY --from=0 /go/bin/kubeadm-bootstrap ./kubeadm-bootstrap
+ENTRYPOINT ["/kubeadm-bootstrap", "--dry-run", "--quiet"]
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Flags:
   -f, --kubeadmfile string   path to kubeadm file to write (default "/etc/kubernetes/kubeadm.json")
   -n, --nodename string      nodename for bootstrap master
   -m, --number int           number of masters in the cluster (default 3)
+      --quiet                suppress logging output
   -s, --svcip string         kubernetes service IP (default "10.96.0.1")
   -t, --token string         kubernetes bootstrap token
 
@@ -47,7 +48,16 @@ Use "kubeadm-bootstrap [command] --help" for more information about a command.
 
 ## Installation
 
-Coming Soon
+You can run this without building it by using the docker container we provide:
+
+docker run apptio/kubeadm-bootstrap \
+    -a 10.0.0.1,10.0.0.2,10.0.0.3 \
+    -c testCluster \
+    -d DC1 \
+    -D example.com \
+    -n boostrapNode \
+    --dry-run \
+    --quiet
 
 ## Assumptions
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -270,7 +270,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVarP(&numberMasters, "number", "m", 3, "number of masters in the cluster")
 	RootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "kubernetes bootstrap token")
 	RootCmd.PersistentFlags().BoolVarP(&dryrun, "dry-run", "", false, "output the kubeadm config to stdout instead of a file")
-    RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet" , "", false, "suppress logging output")
+	RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet" , "", false, "suppress logging output")
 
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,7 @@ var dcName string
 var token string
 var generatedToken string
 var dryrun bool
+var quiet bool
 
 // Version string
 var Version string
@@ -74,6 +75,19 @@ var RootCmd = &cobra.Command{
 	Long: `Generate a kubeadm config for a kubernetes cluster using CIS compatible configuration
 using jsonnet templates for the config file`,
 	Run: func(cmd *cobra.Command, args []string) {
+
+        if quiet {
+            // set logging to /dev/null
+            file, err := os.OpenFile("/dev/null", os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+            if err == nil {
+                log.SetOutput(file)
+            } else {
+                log.Fatal("Unable to open /dev/null.")
+            }
+        } else {
+            // set logging to stderr
+            log.SetOutput(os.Stderr)
+        }
 
 		// read static assets
 		templateBox, err := rice.FindBox("../lib")
@@ -256,6 +270,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVarP(&numberMasters, "number", "m", 3, "number of masters in the cluster")
 	RootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "kubernetes bootstrap token")
 	RootCmd.PersistentFlags().BoolVarP(&dryrun, "dry-run", "", false, "output the kubeadm config to stdout instead of a file")
+    RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet" , "", false, "suppress logging output")
 
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,18 +76,18 @@ var RootCmd = &cobra.Command{
 using jsonnet templates for the config file`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-        if quiet {
-            // set logging to /dev/null
-            file, err := os.OpenFile("/dev/null", os.O_APPEND|os.O_WRONLY, os.ModeAppend)
-            if err == nil {
-                log.SetOutput(file)
-            } else {
-                log.Fatal("Unable to open /dev/null.")
-            }
-        } else {
-            // set logging to stderr
-            log.SetOutput(os.Stderr)
-        }
+		if quiet {
+			// set logging to /dev/null
+			file, err := os.OpenFile("/dev/null", os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+			if err == nil {
+				log.SetOutput(file)
+			} else {
+				log.Fatal("Unable to open /dev/null.")
+			}
+		} else {
+			// set logging to stderr
+			log.SetOutput(os.Stderr)
+		}
 
 		// read static assets
 		templateBox, err := rice.FindBox("../lib")
@@ -270,7 +270,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVarP(&numberMasters, "number", "m", 3, "number of masters in the cluster")
 	RootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "kubernetes bootstrap token")
 	RootCmd.PersistentFlags().BoolVarP(&dryrun, "dry-run", "", false, "output the kubeadm config to stdout instead of a file")
-	RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet" , "", false, "suppress logging output")
+	RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "", false, "suppress logging output")
 
 }
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@
 
 package main
 
-import "github.com/apptio/kubeadm-bootstrap/cmd"
+import "github.com/gregwalters/kubeadm-bootstrap/cmd"
 
 var version = "snapshot"
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@
 
 package main
 
-import "github.com/gregwalters/kubeadm-bootstrap/cmd"
+import "github.com/apptio/kubeadm-bootstrap/cmd"
 
 var version = "snapshot"
 


### PR DESCRIPTION
I've move the logrus output to stderr as I think that any output that typically shouldn't be consumed by another program down a pipe shouldn't go to stdout. Moving the output to stderr also makes it easier to redirect the --dry-run output to a file when ran from a docker container.

I must admit, running this via a docker container isn't the most useful thing since Go is so portable as-is but "Dockerize it" was on a list of things I could do and running in a container gives me a good excuse to make the logging changes I made.